### PR TITLE
Chore/remove api version

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,27 +39,26 @@ npx knex migrate:latest --env test
 
 `sqnc-identity-service` is configured primarily using environment variables as follows:
 
-| variable             | required | default           | description                                                                                                                                          |
-|----------------------|----------|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| SERVICE_TYPE         | N        | `info`            | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                                                 |
-| PORT                 | N        | `3001`            | The port for the API to listen on                                                                                                                    |
-| LOG_LEVEL            | N        | `info`            | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                                                 |
-| API_VERSION          | N        | -                 | API version                                                                                                                                          |
-| API_MAJOR_VERSION    | N        | -                 | API major version                                                                                                                                    |
-| API_HOST             | Y        | -                 | The hostname of the `sqnc-node` the API should connect to                                                                                            |
-| API_PORT             | N        | `9944`            | The port of the `sqnc-node` the API should connect to                                                                                                |
-| LOG_LEVEL            | N        | `info`            | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                                                 |
-| USER_URI             | Y        | -                 | The Substrate `URI` representing the private key to use when making `veritable-node` transactions                                                    |
-| DB_HOST              | Y        | -                 | Hostname for the db                                                                                                                                  |
-| DB_PORT              | N        | 5432              | Port to connect to the db                                                                                                                            |
-| DB_NAME              | N        | `sqnc`            | Name of the database to connect to                                                                                                                   |
-| DB_USERNAME          | Y        | -                 | Username to connect to the database with                                                                                                             |
-| DB_PASSWORD          | Y        | -                 | Password to connect to the database with                                                                                                             |
-| SELF_ADDRESS         | N        | -                 | Instance wallet address that is returned by `/self` endpoint                                                                                         |
-| AUTH_TYPE            | N        | `NONE`            | Authentication type for routes on the service. Valid values: [`NONE`, `JWT`, `EXTERNAL`]                                                             |
-| API_SWAGGER_BG_COLOR | N        | `#fafafa`         | CSS _color_ val for UI bg ( try: [e4f2f3](https://coolors.co/e4f2f3) , [e7f6e6](https://coolors.co/e7f6e6) or [f8dddd](https://coolors.co/f8dddd) )  |
-| API_SWAGGER_TITLE    | N        | `IdentityAPI`     | String used to customise the title of the html page                                                                                                  |
-| API_SWAGGER_HEADING  | N        | `IdentityService` | String used to customise the H2 heading                                                                                                              |
+| variable             | required | default           | description                                                                                                                                         |
+| -------------------- | -------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SERVICE_TYPE         | N        | `info`            | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                                                |
+| PORT                 | N        | `3001`            | The port for the API to listen on                                                                                                                   |
+| LOG_LEVEL            | N        | `info`            | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                                                |
+| API_MAJOR_VERSION    | N        | -                 | API major version                                                                                                                                   |
+| API_HOST             | Y        | -                 | The hostname of the `sqnc-node` the API should connect to                                                                                           |
+| API_PORT             | N        | `9944`            | The port of the `sqnc-node` the API should connect to                                                                                               |
+| LOG_LEVEL            | N        | `info`            | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                                                |
+| USER_URI             | Y        | -                 | The Substrate `URI` representing the private key to use when making `veritable-node` transactions                                                   |
+| DB_HOST              | Y        | -                 | Hostname for the db                                                                                                                                 |
+| DB_PORT              | N        | 5432              | Port to connect to the db                                                                                                                           |
+| DB_NAME              | N        | `sqnc`            | Name of the database to connect to                                                                                                                  |
+| DB_USERNAME          | Y        | -                 | Username to connect to the database with                                                                                                            |
+| DB_PASSWORD          | Y        | -                 | Password to connect to the database with                                                                                                            |
+| SELF_ADDRESS         | N        | -                 | Instance wallet address that is returned by `/self` endpoint                                                                                        |
+| AUTH_TYPE            | N        | `NONE`            | Authentication type for routes on the service. Valid values: [`NONE`, `JWT`, `EXTERNAL`]                                                            |
+| API_SWAGGER_BG_COLOR | N        | `#fafafa`         | CSS _color_ val for UI bg ( try: [e4f2f3](https://coolors.co/e4f2f3) , [e7f6e6](https://coolors.co/e7f6e6) or [f8dddd](https://coolors.co/f8dddd) ) |
+| API_SWAGGER_TITLE    | N        | `IdentityAPI`     | String used to customise the title of the html page                                                                                                 |
+| API_SWAGGER_HEADING  | N        | `IdentityService` | String used to customise the H2 heading                                                                                                             |
 
 The following environment variables are additionally used when `AUTH_TYPE : 'JWT'`
 

--- a/app/api-v1/api-doc.js
+++ b/app/api-v1/api-doc.js
@@ -1,12 +1,13 @@
 import env from '../env.js'
+import version from '../version.js'
 
-const { PORT, API_VERSION, API_MAJOR_VERSION } = env
+const { PORT, API_MAJOR_VERSION } = env
 
 const apiDoc = {
   openapi: '3.0.3',
   info: {
     title: 'IdentityService',
-    version: API_VERSION,
+    version,
   },
   servers: [
     {

--- a/app/env.js
+++ b/app/env.js
@@ -1,8 +1,6 @@
 import envalid from 'envalid'
 import dotenv from 'dotenv'
 
-import version from './version.js'
-
 if (process.env.NODE_ENV === 'test') {
   dotenv.config({ path: 'test/test.env' })
 } else {
@@ -12,9 +10,9 @@ if (process.env.NODE_ENV === 'test') {
 const AUTH_ENVS = {
   NONE: {},
   JWT: {
-    AUTH_JWKS_URI: envalid.url({ devDefault: 'https://inteli.eu.auth0.com/.well-known/jwks.json' }),
-    AUTH_AUDIENCE: envalid.str({ devDefault: 'inteli-dev' }),
-    AUTH_ISSUER: envalid.url({ devDefault: 'https://inteli.eu.auth0.com/' }),
+    AUTH_JWKS_URI: envalid.url({}),
+    AUTH_AUDIENCE: envalid.str({}),
+    AUTH_ISSUER: envalid.url({}),
   },
 }
 
@@ -31,7 +29,6 @@ const vars = envalid.cleanEnv(
     PORT: envalid.port({ default: 3002 }),
     API_HOST: envalid.host({ devDefault: 'localhost' }),
     API_PORT: envalid.port({ default: 9944 }),
-    API_VERSION: envalid.str({ default: version }),
     API_MAJOR_VERSION: envalid.str({ default: 'v1' }),
     LOG_LEVEL: envalid.str({ default: 'info', devDefault: 'debug' }),
     DB_HOST: envalid.host({ devDefault: 'localhost' }),

--- a/app/server.js
+++ b/app/server.js
@@ -6,24 +6,18 @@ import swaggerUi from 'swagger-ui-express'
 import path from 'path'
 import bodyParser from 'body-parser'
 import compression from 'compression'
+import promBundle from 'express-prom-bundle'
+import client from 'prom-client'
 
 import env from './env.js'
 import logger from './logger.js'
 import v1ApiDoc from './api-v1/api-doc.js'
 import v1ApiService from './api-v1/services/apiService.js'
 import { verifyJwks } from './util/authUtil.js'
-import promBundle from 'express-prom-bundle'
-import client from 'prom-client'
 
-const {
-  PORT,
-  API_VERSION,
-  API_MAJOR_VERSION,
-  AUTH_TYPE,
-  API_SWAGGER_BG_COLOR,
-  API_SWAGGER_HEADING,
-  API_SWAGGER_TITLE,
-} = env
+import version from './version.js'
+
+const { PORT, API_MAJOR_VERSION, AUTH_TYPE, API_SWAGGER_BG_COLOR, API_SWAGGER_HEADING, API_SWAGGER_TITLE } = env
 
 import url from 'url'
 const __filename = url.fileURLToPath(import.meta.url)
@@ -65,7 +59,7 @@ export async function createHttpServer() {
   )
 
   app.get('/health', async (req, res) => {
-    res.status(200).send({ version: API_VERSION, status: 'ok' })
+    res.status(200).send({ version, status: 'ok' })
     return
   })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/sqnc-identity-service",
-  "version": "1.10.5",
+  "version": "1.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/sqnc-identity-service",
-      "version": "1.10.5",
+      "version": "1.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.11.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4082,9 +4082,9 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.0.tgz",
-      "integrity": "sha512-0oKGaR+y3qcS5mCu1vb7KG+a89vjn06C7Ihq/dDl3jA+A8B3TKomvi3CiEcVLJQGalbu8F52LxkOym7U5sSfbg==",
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -5769,6 +5769,24 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "node_modules/nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6733,9 +6751,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.28",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.28.tgz",
-      "integrity": "sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw==",
+      "version": "8.4.35",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
+      "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
       "dev": true,
       "funding": [
         {
@@ -6752,30 +6770,12 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/postgres-array": {
@@ -11359,9 +11359,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.0.tgz",
-      "integrity": "sha512-0oKGaR+y3qcS5mCu1vb7KG+a89vjn06C7Ihq/dDl3jA+A8B3TKomvi3CiEcVLJQGalbu8F52LxkOym7U5sSfbg==",
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
       "dev": true
     },
     "has": {
@@ -12583,6 +12583,12 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "dev": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -13324,22 +13330,14 @@
       }
     },
     "postcss": {
-      "version": "8.4.28",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.28.tgz",
-      "integrity": "sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw==",
+      "version": "8.4.35",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
+      "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
-      },
-      "dependencies": {
-        "nanoid": {
-          "version": "3.3.6",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-          "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
-          "dev": true
-        }
       }
     },
     "postgres-array": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/sqnc-identity-service",
-  "version": "1.10.5",
+  "version": "1.11.0",
   "description": "Identity Service for SQNC",
   "type": "module",
   "main": "app/index.js",

--- a/test/integration/httpServer.test.js
+++ b/test/integration/httpServer.test.js
@@ -2,7 +2,6 @@ import { describe, before, test } from 'mocha'
 import { expect } from 'chai'
 
 import { createHttpServer } from '../../app/server.js'
-import env from '../../app/env.js'
 import version from '../../app/version.js'
 import { healthCheck } from '../helper/routeHelper.js'
 

--- a/test/integration/httpServer.test.js
+++ b/test/integration/httpServer.test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai'
 
 import { createHttpServer } from '../../app/server.js'
 import env from '../../app/env.js'
+import version from '../../app/version.js'
 import { healthCheck } from '../helper/routeHelper.js'
 
 describe('health', function () {
@@ -13,7 +14,7 @@ describe('health', function () {
   })
 
   test('health check', async function () {
-    const expectedResult = { status: 'ok', version: env.API_VERSION }
+    const expectedResult = { status: 'ok', version }
 
     const actualResult = await healthCheck(app)
     expect(actualResult.status).to.equal(200)


### PR DESCRIPTION
There's no need for us to set the reported api version externally as this is meant to represent the deployed app version. Removing