### PR TITLE
Chore/configure kc path prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ npm run db:migrate
 | IDP_CLIENT_ID        | Y        | -                       | OAuth2 client-id to use in swagger-ui                                                                                                                 |
 | IDP_PUBLIC_ORIGIN    | Y        | -                       | Origin of IDP from outside the cluster                                                                                                                |
 | IDP_INTERNAL_ORIGIN  | Y        | -                       | Origin of IDP from inside the cluster                                                                                                                 |
+| IDP_PATH_PREFIX      | N        | `/auth`                 | Path prefix to use when constructing IDP API paths.                                                                                                   |
 | IDP_OAUTH2_REALM     | Y        | -                       | Realm to use when authenticating external users                                                                                                       |
 | IDP_INTERNAL_REALM   | Y        | -                       | Realm to use when authenticating cluster internal users                                                                                               |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/sqnc-identity-service",
-  "version": "4.0.5",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/sqnc-identity-service",
-      "version": "4.0.5",
+      "version": "4.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/sqnc-identity-service",
-  "version": "4.0.5",
+  "version": "4.1.0",
   "description": "Identity Service for SQNC",
   "type": "module",
   "main": "src/index.ts",

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -22,10 +22,10 @@ const makeAuth = (securityName: string, jwksUri: string) =>
 export const expressAuthentication = mergeAcceptAny([
   makeAuth(
     'oauth2',
-    `${env.get('IDP_INTERNAL_ORIGIN')}/realms/${env.get('IDP_OAUTH2_REALM')}/protocol/openid-connect/certs`
+    `${env.get('IDP_INTERNAL_ORIGIN')}${env.get('IDP_PATH_PREFIX')}/realms/${env.get('IDP_OAUTH2_REALM')}/protocol/openid-connect/certs`
   ),
   makeAuth(
     'internal',
-    `${env.get('IDP_INTERNAL_ORIGIN')}/realms/${env.get('IDP_INTERNAL_REALM')}/protocol/openid-connect/certs`
+    `${env.get('IDP_INTERNAL_ORIGIN')}${env.get('IDP_PATH_PREFIX')}/realms/${env.get('IDP_INTERNAL_REALM')}/protocol/openid-connect/certs`
   ),
 ])

--- a/src/env.ts
+++ b/src/env.ts
@@ -30,6 +30,10 @@ const envConfig = {
   IDP_INTERNAL_ORIGIN: envalid.url({
     devDefault: 'http://localhost:3080',
   }),
+  IDP_PATH_PREFIX: envalid.str({
+    default: '/auth',
+    devDefault: '',
+  }),
   IDP_OAUTH2_REALM: envalid.str({
     devDefault: 'sequence',
   }),

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -19,11 +19,11 @@ export default async function loadApiSpec(env: Env): Promise<unknown> {
   const swaggerJson = JSON.parse(swaggerBuffer.toString('utf8'))
   swaggerJson.info.title += `:${API_SWAGGER_HEADING}`
 
-  const tokenUrlOauth = `${env.get('IDP_PUBLIC_ORIGIN')}/realms/${env.get('IDP_OAUTH2_REALM')}/protocol/openid-connect/token`
+  const tokenUrlOauth = `${env.get('IDP_PUBLIC_ORIGIN')}${env.get('IDP_PATH_PREFIX')}/realms/${env.get('IDP_OAUTH2_REALM')}/protocol/openid-connect/token`
   swaggerJson.components.securitySchemes.oauth2.flows.clientCredentials.tokenUrl = tokenUrlOauth
   swaggerJson.components.securitySchemes.oauth2.flows.clientCredentials.refreshUrl = tokenUrlOauth
 
-  const tokenUrlInternal = `${env.get('IDP_PUBLIC_ORIGIN')}/realms/${env.get('IDP_INTERNAL_REALM')}/protocol/openid-connect/token`
+  const tokenUrlInternal = `${env.get('IDP_PUBLIC_ORIGIN')}${env.get('IDP_PATH_PREFIX')}/realms/${env.get('IDP_INTERNAL_REALM')}/protocol/openid-connect/token`
   swaggerJson.components.securitySchemes.internal.flows.clientCredentials.tokenUrl = tokenUrlInternal
   swaggerJson.components.securitySchemes.internal.flows.clientCredentials.refreshUrl = tokenUrlInternal
 

--- a/test/helper/auth.ts
+++ b/test/helper/auth.ts
@@ -6,7 +6,7 @@ const env = container.resolve(Env)
 
 export const getToken = async (realm: 'oauth2' | 'internal') => {
   const tokenReq = await fetch(
-    `${env.get('IDP_PUBLIC_ORIGIN')}/realms/${realm === 'oauth2' ? env.get('IDP_OAUTH2_REALM') : env.get('IDP_INTERNAL_REALM')}/protocol/openid-connect/token`,
+    `${env.get('IDP_PUBLIC_ORIGIN')}${env.get('IDP_PATH_PREFIX')}/realms/${realm === 'oauth2' ? env.get('IDP_OAUTH2_REALM') : env.get('IDP_INTERNAL_REALM')}/protocol/openid-connect/token`,
     {
       method: 'POST',
       headers: {


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix
- [x] Chore
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/SQNC-126

## High level description

Adds `IDP_PATH_PREFIX` env

## Detailed description

In production we offset keycloak onto a `/auth` path prefix using `KC_HOSTNAME_PATH` env. This wasn't a problem previously as we hadn't specifcially defined the format of the `IDP_INTERNAL_PREFIX` or similar. Now we construct the URLs in the application we specify this as an origin in the env name and docs and it would be odd to demand a path segment in there. This change introduces an optional variable to set the path prefix. 

I consider this a minor bump as it adds new configuration options. I've avoided a major by setting it to `/auth` by default which is our production value. I'll do a PR to the helm chart after this to carry through the configuration.

## Describe alternatives you've considered

We could just abuse the usage of the `IDP_INTERNAL_ORIGIN` and `IDP_PUBLIC_ORIGIN` args and allow the prefix to just be slapped on the end. This would work without change but is a bit odd. This also brings the change inline with how keycloak itself is configured

## Operational impact

None

## Additional context

None
